### PR TITLE
Add static build and CI

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -1,0 +1,133 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  x86_64:
+      runs-on: ubuntu-20.04
+      name: Build for ${{ matrix.distro }} x86_64 and mipsle
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install requirements
+        run: |
+          echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+          curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
+          sudo apt-get -y update
+          sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
+          sudo apt-get install -y wireguard-tools upx-ucl
+
+      - name: Build x86_64
+        run: |
+          make all static vpp
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-x86_64
+          path: etherguard-go*
+
+      - name: Upload x86_64 dynmatic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go
+          asset_name: etherguard-go-x86_64
+          tag: ${{ github.ref }}
+
+      - name: Upload x86_64 static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-static
+          asset_name: etherguard-go-static-x86_64
+          tag: ${{ github.ref }}
+
+      - name: Build mipsle
+        run: |
+          make clean
+          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static
+          upx -9 etherguard-go*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-mipsle
+          path: etherguard-go*
+
+      - name: Upload mipsle dynmatic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go
+          asset_name: etherguard-go-mipsle
+          tag: ${{ github.ref }}
+
+      - name: Upload mipsle static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-static
+          asset_name: etherguard-go-static-mipsle
+          tag: ${{ github.ref }}
+
+  multi-arch:
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: armv7
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+          env: |
+            artifact_dir: ${{ matrix.arch }}
+          shell: /bin/sh
+          install: |
+            apt-get -y update
+            apt install software-properties-common -y
+            add-apt-repository ppa:longsleep/golang-backports
+            apt-get -y update
+            apt-get install -y wireguard-tools golang-go build-essential git
+          run: |
+            make all static vpp
+            mkdir /artifacts/${artifact_dir}
+            cp etherguard-go* /artifacts/${artifact_dir}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-multi_arch
+          path: artifacts/
+
+      - name: Upload dynmatic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/${{ martix.arch }}/etherguard-go
+          asset_name: etherguard-go-${{ martix.arch }}
+          tag: ${{ github.ref }}
+
+      - name: Upload static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/${{ martix.arch }}/etherguard-go-static
+          asset_name: etherguard-go-static-${{ martix.arch }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,7 +68,7 @@ jobs:
           shell: /bin/sh
           install: |
             apt-get -y update
-            apt install software-properties-common -y
+            apt install software-properties-common curl -y
             add-apt-repository ppa:longsleep/golang-backports
             echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
             curl -L https://packagecloud.io/fdio/release/gpgkey | apt-key add -
@@ -76,7 +76,7 @@ jobs:
             apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
-            make all static vpp static-vpp
+            make all static vpp
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,6 +71,7 @@ jobs:
             artifact_dir: ${{ matrix.arch }}
           shell: /bin/sh
           install: |
+            apt-get -y update
             apt install software-properties-common -y
             add-apt-repository ppa:longsleep/golang-backports
             apt-get -y update

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,23 +4,39 @@ on:
   - workflow_dispatch
 
 jobs:
-
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: armv7
+          - arch: armv6
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Install requirements
-      run: sudo apt-get install -y wireguard-tools
-
-    - name: Build
-      run: make generate-version-and-build static
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu-20.04
+          githubToken: ${{ github.token }}
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+          env:
+            artifact_dir: ${{ matrix.arch }}
+          shell: /bin/sh
+          install: |
+            sudo apt-get install -y wireguard-tools
+          run: |
+            make generate-version-and-build static
+            mkdir /artifacts/${artifact_dir}
+            cp etherguard-go* /artifacts/${artifact_dir}
 
     - uses: actions/upload-artifact@v2
       with:
-        name: etherguard
-        path: etherguard-go*
+        name: build
+        path: /artifacts/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,7 @@ jobs:
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: /artifacts/*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: /artifacts/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,4 +18,9 @@ jobs:
       run: sudo apt-get install -y wireguard-tools
 
     - name: Build
-      run: make static
+      run: make generate-version-and-build static
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: etherguard
+        path: etherguard-go*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,4 +75,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: etherguard-multi_arch
-          path: /artifacts/*
+          path: /artifacts

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,9 @@
-name: Go
+name: Publish
 
 on:
-  - workflow_dispatch
+  push:
+    tags:
+      - '*'
 
 jobs:
   x86_64:
@@ -68,12 +70,9 @@ jobs:
           shell: /bin/sh
           install: |
             apt-get -y update
-            apt install software-properties-common curl -y
+            apt install software-properties-common -y
             add-apt-repository ppa:longsleep/golang-backports
-            echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
-            curl -L https://packagecloud.io/fdio/release/gpgkey | apt-key add -
             apt-get -y update
-            apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
             make all static vpp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,6 @@ jobs:
         include:
           - arch: aarch64
           - arch: armv7
-          - arch: armv6
     steps:
       - uses: actions/checkout@v2
       - uses: uraimo/run-on-arch-action@v2.0.5

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,26 @@ on:
   - workflow_dispatch
 
 jobs:
-  build:
+  x86_64:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install requirements
+        run: sudo apt-get install -y wireguard-tools
+
+      - name: Build
+        run: make generate-version-and-build static
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-x86_64
+          path: etherguard-go*
+  multi-arch:
     runs-on: ubuntu-20.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
     strategy:
@@ -20,7 +39,7 @@ jobs:
         id: build
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu-20.04
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
           setup: |
             mkdir -p "${PWD}/artifacts"
@@ -30,6 +49,8 @@ jobs:
             artifact_dir: ${{ matrix.arch }}
           shell: /bin/sh
           install: |
+            sudo add-apt-repository ppa:longsleep/golang-backports
+            sudo apt-get -y update
             sudo apt-get install -y wireguard-tools
           run: |
             make generate-version-and-build static
@@ -38,5 +59,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: etherguard-multi_arch
           path: /artifacts/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   x86_64:
       runs-on: ubuntu-latest
+      name: Build on ${{ matrix.distro }} x86_64
       steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,7 @@
-name: Publish
+name: Go
 
 on:
-  push:
-    tags:
-      - '*'
+  - workflow_dispatch
 
 jobs:
   x86_64:
@@ -43,6 +41,7 @@ jobs:
         with:
           name: etherguard-mipsle
           path: etherguard-go*
+
 
   multi-arch:
     runs-on: ubuntu-20.04

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,11 @@ jobs:
           go-version: 1.17
       - name: Install requirements
         run: |
-        echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
-        curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
-        sudo apt-get -y update
-        sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
-        sudo apt-get install -y wireguard-tools upx-ucl
+          echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+          curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
+          sudo apt-get -y update
+          sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
+          sudo apt-get install -y wireguard-tools upx-ucl
 
       - name: Build x86_64
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   x86_64:
       runs-on: ubuntu-latest
-      name: Build on ${{ matrix.distro }} x86_64
+      name: Build for ${{ matrix.distro }} x86_64 and mipsle
       steps:
       - uses: actions/checkout@v2
 
@@ -15,31 +15,22 @@ jobs:
         with:
           go-version: 1.17
       - name: Install requirements
-        run: sudo apt-get install -y wireguard-tools
+        run: sudo apt-get install -y wireguard-tools upx-ucl
 
-      - name: Build
-        run: make generate-version-and-build static
+      - name: Build x86_64
+        run: |
+          make all static vpp static-vpp
 
       - uses: actions/upload-artifact@v2
         with:
           name: etherguard-x86_64
           path: etherguard-go*
 
-  mipsle:
-      runs-on: ubuntu-latest
-      name: Build on ${{ matrix.distro }} mipsle
-      steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - name: Install requirements
-        run: sudo apt-get install -y wireguard-tools
-
-      - name: Build
-        run: GOOS=linux GOARCH=mipsle GOMIPS=softfloat make generate-version-and-build static
+      - name: Build mipsle
+        run: |
+          make clean
+          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static vpp static-vpp
+          upx -9 etherguard-go*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,10 +70,13 @@ jobs:
             apt-get -y update
             apt install software-properties-common -y
             add-apt-repository ppa:longsleep/golang-backports
+            echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+            curl -L https://packagecloud.io/fdio/release/gpgkey | apt-key add -
             apt-get -y update
+            apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
-            make generate-version-and-build static
+            make all static vpp static-vpp
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,28 @@ jobs:
         with:
           name: etherguard-x86_64
           path: etherguard-go*
+
+  mipsle:
+      runs-on: ubuntu-latest
+      name: Build on ${{ matrix.distro }} mipsle
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install requirements
+        run: sudo apt-get install -y wireguard-tools
+
+      - name: Build
+        run: GOOS=linux GOARCH=mipsle GOMIPS=softfloat make generate-version-and-build static
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-mipsle
+          path: etherguard-go*
+
   multi-arch:
     runs-on: ubuntu-20.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
@@ -49,9 +71,10 @@ jobs:
             artifact_dir: ${{ matrix.arch }}
           shell: /bin/sh
           install: |
+            apt install software-properties-common -y
             add-apt-repository ppa:longsleep/golang-backports
             apt-get -y update
-            apt-get install -y wireguard-tools
+            apt-get install -y wireguard-tools golang-go build-essential git
           run: |
             make generate-version-and-build static
             mkdir /artifacts/${artifact_dir}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
             mkdir -p "${PWD}/artifacts"
           dockerRunArgs: |
             --volume "${PWD}/artifacts:/artifacts"
-          env:
+          env: |
             artifact_dir: ${{ matrix.arch }}
           shell: /bin/sh
           install: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,7 +74,7 @@ jobs:
             apt-get -y update
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
-            make all static vpp
+            make all static
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,9 +49,9 @@ jobs:
             artifact_dir: ${{ matrix.arch }}
           shell: /bin/sh
           install: |
-            sudo add-apt-repository ppa:longsleep/golang-backports
-            sudo apt-get -y update
-            sudo apt-get install -y wireguard-tools
+            add-apt-repository ppa:longsleep/golang-backports
+            apt-get -y update
+            apt-get install -y wireguard-tools
           run: |
             make generate-version-and-build static
             mkdir /artifacts/${artifact_dir}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build x86_64
         run: |
-          make all static vpp static-vpp
+          make all static vpp
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,4 +18,4 @@ jobs:
       run: sudo apt-get install -y wireguard-tools
 
     - name: Build
-      run: make
+      run: make static

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   x86_64:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       name: Build for ${{ matrix.distro }} x86_64 and mipsle
       steps:
       - uses: actions/checkout@v2
@@ -15,7 +15,12 @@ jobs:
         with:
           go-version: 1.17
       - name: Install requirements
-        run: sudo apt-get install -y wireguard-tools upx-ucl
+        run: |
+        echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+        curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
+        sudo apt-get -y update
+        sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
+        sudo apt-get install -y wireguard-tools upx-ucl
 
       - name: Build x86_64
         run: |
@@ -29,7 +34,7 @@ jobs:
       - name: Build mipsle
         run: |
           make clean
-          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static vpp static-vpp
+          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static
           upx -9 etherguard-go*
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,4 +83,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: etherguard-multi_arch
-          path: /artifacts
+          path: artifacts/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
             apt-get -y update
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
-            make all static vpp
+            make all static
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           name: etherguard-x86_64
           path: etherguard-go*
 
-      - name: Upload x86_64 dynmatic build
+      - name: Upload x86_64 dynamic build
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           name: etherguard-mipsle
           path: etherguard-go*
 
-      - name: Upload mipsle dynmatic build
+      - name: Upload mipsle dynamic build
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
           name: etherguard-multi_arch
           path: artifacts/
 
-      - name: Upload dynmatic build
+      - name: Upload dynamic build
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ etherguard-go: $(wildcard *.go) $(wildcard */*.go)
 	go mod vendor && \
 	go build -v -o "$@"
 
+etherguard-go-static: $(wildcard *.go) $(wildcard */*.go)
+	go mod download && \
+	go mod tidy && \
+	go mod vendor && \
+	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"'  -v -o "$@"
+
 vpp:
 	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
 	tag="$$(git describe 2>/dev/null)" && \
@@ -38,6 +44,24 @@ etherguard-go-vpp: $(wildcard *.go) $(wildcard */*.go)
 	go mod vendor && \
 	patch -p0 -i govpp_remove_crcstring_check.patch && \
 	go build -v -tags vpp -o "$@"
+
+static:
+    @export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	tag="$$(git describe 2>/dev/null)" && \
+	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
+	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
+	echo "$$ver" > version.go && \
+	git update-index --assume-unchanged version.go || true
+	@$(MAKE) etherguard-go-static
+
+static-vpp:
+    @export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	tag="$$(git describe 2>/dev/null)" && \
+	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
+	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
+	echo "$$ver" > version.go && \
+	git update-index --assume-unchanged version.go || true
+	@$(MAKE) etherguard-go-vpp-static
 
 install: etherguard-go
 	@install -v -d "$(DESTDIR)$(BINDIR)" && install -v -m 0755 "$<" "$(DESTDIR)$(BINDIR)/etherguard-go"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ etherguard-go-static: $(wildcard *.go) $(wildcard */*.go)
 	go mod download && \
 	go mod tidy && \
 	go mod vendor && \
-	CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"'  -v -o "$@"
+	CGO_ENABLED=0 go build -a -trimpath -ldflags '-s -w -extldflags "-static"'  -v -o "$@"
 
 vpp:
 	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
@@ -44,6 +44,13 @@ etherguard-go-vpp: $(wildcard *.go) $(wildcard */*.go)
 	go mod vendor && \
 	patch -p0 -i govpp_remove_crcstring_check.patch && \
 	go build -v -tags vpp -o "$@"
+
+etherguard-go-vpp-static: $(wildcard *.go) $(wildcard */*.go)
+	go mod download && \
+	go mod tidy && \
+	go mod vendor && \
+	patch -p0 -i govpp_remove_crcstring_check.patch && \
+	CGO_ENABLED=0 go build -trimpath -a -ldflags '-s -w -extldflags "-static"'  -v -tags vpp -o "$@"
 
 static:
 	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ etherguard-go-vpp: $(wildcard *.go) $(wildcard */*.go)
 	go build -v -tags vpp -o "$@"
 
 static:
-    @export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
 	tag="$$(git describe 2>/dev/null)" && \
 	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
 	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
@@ -55,7 +55,7 @@ static:
 	@$(MAKE) etherguard-go-static
 
 static-vpp:
-    @export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
 	tag="$$(git describe 2>/dev/null)" && \
 	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
 	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ test:
 
 clean:
 	rm -f etherguard-go
+	rm -f etherguard-go-static
 	rm -f etherguard-go-vpp
+	rm -f etherguard-go-vpp-static
 
 .PHONY: all clean test install generate-version-and-build


### PR DESCRIPTION
This PR provides following features:  
* statically linked build to `Makefile`.  
* Github Action workflow to upload build results on multiple arch when publish a new release.  

You can build statically linked executables by using `make static` and `make vpp-statc`.  

Following arch are supported in workflow:   
|   | no-vpp version, dynamic  | no-vpp version, static | vpp version, static | vpp version, static |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| x86_64  | ✔️ | ✔️ |   |    |
| mipsle   | ✔️ | ✔️ | ⛔ | ⛔ |
| aarch64 | ✔️ | ✔️ |   |    |
| armv7   | ✔️ | ✔️ |   |    |

